### PR TITLE
chore: Add arm64 supported label in QBO CSV [PROJQUAY-9888]

### DIFF
--- a/bundle/downstream/manifests/quay-bridge-operator.clusterserviceversion.yaml
+++ b/bundle/downstream/manifests/quay-bridge-operator.clusterserviceversion.yaml
@@ -43,6 +43,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
 spec:
   apiservicedefinitions: {}

--- a/bundle/upstream/manifests/quay-bridge-operator.clusterserviceversion.yaml
+++ b/bundle/upstream/manifests/quay-bridge-operator.clusterserviceversion.yaml
@@ -41,6 +41,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
 spec:
   apiservicedefinitions: {}


### PR DESCRIPTION
Add arm64 supported label in CSV, then openshift UI could display operator info