### PR TITLE
chore: Add arm64 supported label in QBO CSV [PROJQUAY-9888]

### DIFF
--- a/bundle/downstream/manifests/quay-bridge-operator.clusterserviceversion.yaml
+++ b/bundle/downstream/manifests/quay-bridge-operator.clusterserviceversion.yaml
@@ -43,6 +43,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
 spec:
   apiservicedefinitions: {}

--- a/bundle/upstream/manifests/quay-bridge-operator.clusterserviceversion.yaml
+++ b/bundle/upstream/manifests/quay-bridge-operator.clusterserviceversion.yaml
@@ -41,6 +41,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
 spec:
   apiservicedefinitions: {}


### PR DESCRIPTION
## Summary

- Adds `operatorframework.io/arch.arm64: supported` label to both downstream and upstream ClusterServiceVersion manifests
- Enables arm64 architecture support declaration for the Quay Bridge Operator

This is a rebased version of #204 on current upstream master to fix the CI build failure caused by the old branch base.

Resolves: [PROJQUAY-9888](https://redhat.atlassian.net/browse/PROJQUAY-9888)