### PR TITLE
Merge master into redhat-3.18 for 3.18.0 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,18 @@ Read the specific documentation below if your task involves these keywords:
 - **Style**: Follow existing Go idioms, use controller-runtime patterns
 - **Testing**: Mocks in `pkg/client/quay/mocks/`, use envtest for controller tests
 - **Safety**: Never commit secrets; webhook requires TLS certificates
+
+## Contextification Addendum
+
+Low-token routing:
+
+- API type: `api/v1/`
+- Controllers: `controllers/`
+- Quay client: `pkg/client/quay/`
+- Webhook: `pkg/webhook/`
+- Samples/manifests: `config/`
+- E2E helper: `hack/test-e2e.sh`
+
+Commands: `make build`, `make test`, `make fmt && make vet`, `make run`, `make deploy IMG=<image>`, `make test-e2e`.
+
+Guardrails: keep `QuayIntegration` compatible, never commit OAuth tokens or kubeconfigs, and preserve webhook TLS behavior.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,178 @@
+# quay-bridge-operator Architecture
+
+## Purpose
+
+Integrate Quay with OpenShift ImageStreams and builds.
+
+```mermaid
+flowchart LR
+    cr[QuayIntegration CR]
+    operator[quay-bridge-operator]
+    quay[Quay API and repositories]
+    streams[OpenShift ImageStreams]
+    secrets[Pull secrets]
+    builds[OpenShift builds]
+
+    cr --> operator
+    operator <--> quay
+    operator --> streams
+    operator --> secrets
+    streams --> builds
+```
+
+## High-Level Design
+
+```
+QuayIntegration CR
+    ↓
+quay-bridge-operator
+    ↓ Sync
+Quay repos ↔ ImageStreams
+    ↓ Trigger
+OpenShift Builds
+```
+
+## Components
+
+### `/api/v1alpha1`
+CRD definitions:
+- `QuayIntegration`: Main CR for Quay-OpenShift integration
+  - Quay org/namespace to sync
+  - ImageStream naming strategy
+  - Secret synchronization config
+
+### `/controllers`
+Reconciliation logic:
+- `quayintegration_controller.go`: Main reconciler
+- Sync Quay repos → ImageStreams
+- Sync Quay secrets → OpenShift Secrets
+- Trigger builds on image push
+
+## Sync Flow
+
+```
+1. QuayIntegration CR created:
+   apiVersion: quay.redhat.com/v1alpha1
+   kind: QuayIntegration
+   metadata:
+     name: quay-sync
+   spec:
+     quayOrganization: myorg
+     credentialsSecret: quay-token
+     insecureRegistry: false
+
+2. Operator queries Quay API:
+   GET https://quay.io/api/v1/repository?namespace=myorg
+
+3. For each repo:
+   a. Create/update ImageStream in current namespace
+      name: quay-myorg-<reponame>
+      tags: [latest, v1.0.0, ...]
+   b. Import image tags (oc import-image equivalent)
+
+4. Watch Quay webhooks (if configured):
+   Quay push event → operator updates ImageStream → triggers OpenShift Build
+
+5. Sync Quay robot account secrets:
+   Quay robot → OpenShift Secret (type: dockerconfigjson)
+```
+
+## ImageStream Mapping
+
+```
+Quay repo: quay.io/myorg/app
+    ↓
+OpenShift ImageStream:
+  name: quay-myorg-app
+  tags:
+    - name: latest
+      from: quay.io/myorg/app:latest
+    - name: v1.0.0
+      from: quay.io/myorg/app:v1.0.0
+```
+
+## Secret Synchronization
+
+```
+Quay robot account: myorg+builder
+    ↓
+OpenShift Secret:
+  name: quay-myorg-builder
+  type: kubernetes.io/dockerconfigjson
+  data:
+    .dockerconfigjson: <base64-encoded-creds>
+
+Linked to ServiceAccount:
+  - For pulling (ImagePullSecrets)
+  - For building (BuildConfigs)
+```
+
+## Build Triggering
+
+```
+1. Image pushed to Quay: quay.io/myorg/base:v2.0.0
+
+2. Quay webhook → operator
+
+3. Operator updates ImageStream tag
+
+4. ImageStream change triggers BuildConfig:
+   apiVersion: build.openshift.io/v1
+   kind: BuildConfig
+   spec:
+     triggers:
+       - type: ImageChange
+         imageChange:
+           from:
+             kind: ImageStreamTag
+             name: quay-myorg-base:v2.0.0
+
+5. Build executes, pushes result to Quay
+```
+
+## Reconciliation Loop
+
+```
+Every 5 minutes (or on CR change):
+1. Fetch repos from Quay org
+2. Compare with existing ImageStreams
+3. Create missing ImageStreams
+4. Update changed ImageStreams (new tags)
+5. Delete ImageStreams for deleted repos (if pruning enabled)
+6. Sync secrets (if changed in Quay)
+7. Update QuayIntegration.status
+```
+
+## Configuration
+
+```yaml
+apiVersion: quay.redhat.com/v1alpha1
+kind: QuayIntegration
+metadata:
+  name: example
+spec:
+  quayOrganization: myorg
+  credentialsSecret: quay-creds
+  insecureRegistry: false
+  scheduledImageStreamImport: true
+  importCredentialsSecret: quay-pull-secret
+```
+
+## Status Reporting
+
+```yaml
+status:
+  lastSyncTime: "2026-06-24T12:00:00Z"
+  syncedRepositories: 42
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: SyncComplete
+```
+
+## Performance
+
+- Batched ImageStream updates
+- Incremental sync (only changed repos)
+- Rate limiting to Quay API
+- Webhook-based updates (no polling)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to quay-bridge-operator
+
+## Setup
+
+```bash
+# Requires OpenShift cluster
+make install
+make deploy
+```
+
+## Development
+
+Integrates Quay with OpenShift:
+- Syncs Quay repos → ImageStreams
+- Triggers builds from ImageStream changes
+- Secrets synchronization
+
+## Testing
+
+```bash
+# Unit tests
+make test
+
+# E2E (requires OpenShift + Quay)
+make test-e2e
+```
+
+## Pull Requests
+
+- Test on OpenShift 4.x
+- Verify ImageStream sync doesn't create loops
+- Test secret rotation scenarios
+- Update bundle/ for OLM changes
+
+## Code Structure
+
+- `api/v1alpha1/` - CRD types
+- `controllers/` - reconciliation logic
+- `config/` - deployment manifests
+- `bundle/` - OLM metadata

--- a/README.md
+++ b/README.md
@@ -214,3 +214,24 @@ Once the command completes, navigate to Quay and confirm the _openshift_e2e-demo
 Best practices dictate that all communications between a client and an image registry be facilitated through secure means. Communications should all leverage HTTPS/TLS with a certificate trust between the parties. While Quay can be configured to serve in an insecure configuration, proper certificates should be utilized on the server and configured on the client. Follow the [OpenShift documentation](https://docs.openshift.com/container-platform/4.7/security/certificate_types_descriptions/proxy-certificates.html) for adding and managing certificates at the container runtime level. 
 
 
+## Contextification Addendum
+
+```mermaid
+flowchart LR
+    cr[QuayIntegration CR]
+    operator[quay-bridge-operator]
+    quay[Quay API]
+    streams[ImageStreams]
+    secrets[Robot pull secrets]
+    builds[OpenShift Builds]
+
+    cr --> operator
+    operator <--> quay
+    operator --> streams
+    operator --> secrets
+    streams --> builds
+```
+
+Key paths: `api/v1/`, `controllers/`, `pkg/client/quay/`, `pkg/webhook/`, `config/`, and `hack/test-e2e.sh`.
+
+Use `make build`, `make test`, `make fmt && make vet`, `make run`, `make deploy IMG=<image>`, and `make test-e2e`.


### PR DESCRIPTION
Sync redhat-3.18 with latest changes from master for the Quay 3.18.0 release.